### PR TITLE
Replacing pins.createBuffer() with control.createBuffer(), for RPi has not

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -82,10 +82,10 @@ namespace shader {
 
     function shadeImage(target: Image, left: number, top: number, mask: Image, palette: Buffer) {
         if (!screenRowsBuffer || screenRowsBuffer.length < target.height) {
-            screenRowsBuffer = pins.createBuffer(target.height);
+            screenRowsBuffer = control.createBuffer(target.height);
         }
         if (!maskRowsBuffer || maskRowsBuffer.length < target.height) {
-            maskRowsBuffer = pins.createBuffer(mask.height);
+            maskRowsBuffer = control.createBuffer(mask.height);
         }
 
         let targetX = left | 0;

--- a/pxt.json
+++ b/pxt.json
@@ -15,7 +15,7 @@
         "test.ts"
     ],
     "targetVersions": {
-        "target": "1.2.10",
+        "target": "1.8.22",
         "targetId": "arcade"
     },
     "supportedTargets": [


### PR DESCRIPTION
**Phenomenon:**
When using this ext on hardware target RPi, would get following error
![image](https://user-images.githubusercontent.com/25360426/157145637-5f2f488e-10bf-49d9-81be-64262e83d701.png)

**Cause:**
RPi target has no createBuffer() in pins namespace.

**Solution:**
Relace it with control.createBuffer(). Functionality of both are the same, they all result in mkbuffer() 
